### PR TITLE
Document epoll build steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+This repository contains a Cython-based epoll network backend.
+
+To run the full test suite, including tests marked with `epoll`, the extension must be compiled first.
+
+Steps for testing:
+
+1. Install development dependencies (includes `Cython`):
+   ```bash
+   pip install -e .[dev] -e .[test]
+   ```
+2. Build the Cython extension in place:
+   ```bash
+   python setup.py build_ext --inplace
+   ```
+3. Run the tests normally with `pytest`.
+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ pip install -e .
 
 # Install development dependencies
 pip install -e ".[dev]"
+# Install test dependencies
+pip install -e ".[test]"
+
+# Build the epoll extension (Linux only)
+python setup.py build_ext --inplace
+
+```
+
+After building, you can run the epoll-specific tests:
+
+```bash
+pytest -m epoll
 ```
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0", "wheel", "Cython>=3.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -23,6 +23,15 @@ test = [
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",
     "pytest-benchmark>=4.0.0",
+]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "black>=22.0.0",
+    "mypy>=1.0.0",
+    "pre-commit>=2.20.0",
+    "pytest-cov>=4.0.0",
+    "Cython>=3.0",
 ]
 
 [tool.setuptools]

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,12 @@ def main():
                 "pytest-cov>=4.0.0",
                 "Cython>=3.0",
             ],
+            "test": [
+                "pytest>=7.0.0",
+                "pytest-asyncio>=0.21.0",
+                "pytest-cov>=4.0.0",
+                "pytest-benchmark>=4.0.0",
+            ],
             "docs": [
                 "sphinx>=4.0.0",
                 "sphinx-rtd-theme>=1.0.0",


### PR DESCRIPTION
## Summary
- describe how to compile the epoll extension
- note epoll build in AGENTS instructions
- include dev extras in `pyproject.toml` and `setup.py`
- require Cython when building from source

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68816c39b29c83318bc5de6003361496